### PR TITLE
Pblti 104 multiple canvas instance

### DIFF
--- a/src/lti/Database.php
+++ b/src/lti/Database.php
@@ -4,6 +4,7 @@ namespace IMSGlobal\LTI;
 interface Database {
     public function find_registration_by_issuer($iss);
     public function find_deployment($iss, $deployment_id);
+    public function filter_registrations($filters);
 }
 
 ?>

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -1,1 +1,382 @@
-<?phpnamespace IMSGlobal\LTI;use Firebase\JWT\JWK;use Firebase\JWT\JWT;class LTI_Message_Launch {    private $db;    private $cache;    private $request;    private $cookie;    private $jwt;    private $registration;    private $launch_id;    /**     * Constructor     *     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.     */    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {        $this->db = $database;        $this->launch_id = uniqid("lti1p3_launch_", true);        if ($cache === null) {            $cache = new Cache();        }        $this->cache = $cache;        if ($cookie === null) {            $cookie = new Cookie();        }        $this->cookie = $cookie;        JWT::$leeway = 5;    }    /**     * Static function to allow for method chaining without having to assign to a variable first.     */    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {        return new LTI_Message_Launch($database, $cache, $cookie);    }    /**     * Load an LTI_Message_Launch from a Cache using a launch id.     *     * @param string    $launch_id  The launch id of the LTI_Message_Launch object that is being pulled from the cache.     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.     *     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails or launch cannot be found.     * @return LTI_Message_Launch   A populated and validated LTI_Message_Launch.     */    public static function from_cache($launch_id, Database $database, Cache $cache = null) {        $new = new LTI_Message_Launch($database, $cache, null);        $new->launch_id = $launch_id;        $new->jwt = [ 'body' => $new->cache->get_launch_data($launch_id) ];        return $new->validate_registration();    }    /**     * Validates all aspects of an incoming LTI message launch and caches the launch if successful.     *     * @param array|string  $request    An array of post request parameters. If not set will default to $_POST.     *     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails.     * @return LTI_Message_Launch   Will return $this if validation is successful.     */    public function validate(array $request = null) {        if ($request === null) {            $request = $_POST;        }        $this->request = $request;        return $this->validate_state()            ->validate_jwt_format()            ->validate_nonce()            ->validate_registration()            ->validate_jwt_signature()            ->validate_deployment()            ->validate_message()            ->cache_launch_data();    }    /**     * Returns whether or not the current launch can use the names and roles service.     *     * @return boolean  Returns a boolean indicating the availability of names and roles.     */    public function has_nrps() {        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']['context_memberships_url']);    }    /**     * Fetches an instance of the names and roles service for the current launch.     *     * @return LTI_Names_Roles_Provisioning_Service An instance of the names and roles service that can be used to make calls within the scope of the current launch.     */    public function get_nrps() {        return new LTI_Names_Roles_Provisioning_Service(            new LTI_Service_Connector($this->registration),            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']);    }    /**     * Returns whether or not the current launch can use the groups service.     *     * @return boolean  Returns a boolean indicating the availability of groups.     */    public function has_gs() {        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']['context_groups_url']);    }    /**     * Fetches an instance of the groups service for the current launch.     *     * @return LTI_Course_Groups_Service An instance of the groups service that can be used to make calls within the scope of the current launch.     */    public function get_gs() {        return new LTI_Course_Groups_Service(            new LTI_Service_Connector($this->registration),            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']);    }    /**     * Returns whether or not the current launch can use the assignments and grades service.     *     * @return boolean  Returns a boolean indicating the availability of assignments and grades.     */    public function has_ags() {        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);    }    /**     * Fetches an instance of the assignments and grades service for the current launch.     *     * @return LTI_Assignments_Grades_Service An instance of the assignments an grades service that can be used to make calls within the scope of the current launch.     */    public function get_ags() {        return new LTI_Assignments_Grades_Service(            new LTI_Service_Connector($this->registration),            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);    }    /**     * Fetches a deep link that can be used to construct a deep linking response.     *     * @return LTI_Deep_Link An instance of a deep link to construct a deep linking response for the current launch.     */    public function get_deep_link() {        return new LTI_Deep_Link(            $this->registration,            $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']);    }    /**     * Returns whether or not the current launch is a deep linking launch.     *     * @return boolean  Returns true if the current launch is a deep linking launch.     */    public function is_deep_link_launch() {        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiDeepLinkingRequest';    }    /**     * Returns whether or not the current launch is a submission review launch.     *     * @return boolean  Returns true if the current launch is a submission review launch.     */    public function is_submission_review_launch() {        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiSubmissionReviewRequest';    }    /**     * Returns whether or not the current launch is a resource launch.     *     * @return boolean  Returns true if the current launch is a resource launch.     */    public function is_resource_launch() {        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiResourceLinkRequest';    }    /**     * Fetches the decoded body of the JWT used in the current launch.     *     * @return array|object Returns the decoded json body of the launch as an array.     */    public function get_launch_data() {        return $this->jwt['body'];    }    /**     * Get the unique launch id for the current launch.     *     * @return string   A unique identifier used to re-reference the current launch in subsequent requests.     */    public function get_launch_id() {        return $this->launch_id;    }    /**     * Set Firebase\JWT leeway parameter to avoid synchronization issue between     * local server time and server which created the JWT     *     * @param int $leeway     *     * @return int     */    public function set_jwt_leeway( int $leeway ) {        JWT::$leeway = $leeway;        return JWT::$leeway;    }    private function get_public_key() {        $key_set_url = $this->registration->get_key_set_url();        // Download key set        $public_key_set = json_decode(file_get_contents($key_set_url), true);        if (empty($public_key_set)) {            // Failed to fetch public keyset from URL.            throw new LTI_Exception("Failed to fetch public key", 1);        }        // Find key used to sign the JWT (matches the KID in the header)        foreach ($public_key_set['keys'] as $key) {            if ($key['kid'] == $this->jwt['header']['kid']) {                try {                    return openssl_pkey_get_details(JWK::parseKey($key));                } catch(\Exception $e) {                    return false;                }            }        }        // Could not find public key with a matching kid and alg.        throw new LTI_Exception("Unable to find public key", 1);    }    private function cache_launch_data() {        $this->cache->cache_launch_data($this->launch_id, $this->jwt['body']);        return $this;    }    private function validate_state() {        // Check State for OIDC.        if ($this->cookie->get_cookie('lti1p3_' . $this->request['state']) !== $this->request['state']) {            // Error if state doesn't match            throw new LTI_Exception("State not found", 1);        }        return $this;    }    private function validate_jwt_format() {        $jwt = $this->request['id_token'];        if (empty($jwt)) {            throw new LTI_Exception("Missing id_token", 1);        }        // Get parts of JWT.        $jwt_parts = explode('.', $jwt);        if (count($jwt_parts) !== 3) {            // Invalid number of parts in JWT.            throw new LTI_Exception("Invalid id_token, JWT must contain 3 parts", 1);        }        // Decode JWT headers.        $this->jwt['header'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[0]), true);        // Decode JWT Body.        $this->jwt['body'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[1]), true);        return $this;    }    private function validate_nonce() {        if (!$this->cache->check_nonce($this->jwt['body']['nonce'])) {            //throw new LTI_Exception("Invalid Nonce");        }        return $this;    }    private function validate_registration() {        // Check client id.        $client_id = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];        // Find registration by iss and client_id.        $registrations = $this->db->filter_registrations([            'iss' => $this->jwt['body']['iss'],            'aud' => $client_id        ]);        if (!$registrations || count($registrations) === 0) {            throw new LTI_Exception("Registration not found.", 1);        }        $this->registration = $registrations[0];        return $this;    }    private function validate_jwt_signature() {        // Fetch public key.        $public_key = $this->get_public_key();        // Validate JWT signature        try {            JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));        } catch(\Exception $e) {            var_dump($e);            // Error validating signature.            throw new LTI_Exception("Invalid signature on id_token", 1);        }        return $this;    }    private function validate_deployment() {        // Find deployment.        $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id']);        if (empty($deployment)) {            // deployment not recognized.            throw new LTI_Exception("Unable to find deployment", 1);        }        return $this;    }    private function validate_message() {        if (empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'])) {            // Unable to identify message type.            throw new LTI_Exception("Invalid message type", 1);        }        // Do message type validation        // Import all validators        foreach (glob(__DIR__ . "/message_validators/*.php") as $filename) {            include_once $filename;        }        // Create instances of all validators        $classes = get_declared_classes();        $validators = array();        foreach ($classes as $class_name) {            // Check the class implements message validator            $reflect = new \ReflectionClass($class_name);            if ($reflect->implementsInterface('\IMSGlobal\LTI\Message_Validator')) {                // Create instance of class                $validators[] = new $class_name();            }        }        $message_validator = false;        foreach ($validators as $validator) {            if ($validator->can_validate($this->jwt['body'])) {                if ($message_validator !== false) {                    // Can't have more than one validator apply at a time.                    throw new LTI_Exception("Validator conflict", 1);                }                $message_validator = $validator;            }        }        if ($message_validator === false) {            throw new LTI_Exception("Unrecognized message type.", 1);        }        if (!$message_validator->validate($this->jwt['body'])) {            throw new LTI_Exception("Message validation failed.", 1);        }        return $this;    }}?>
+<?php
+namespace IMSGlobal\LTI;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+
+class LTI_Message_Launch {
+
+    private $db;
+    private $cache;
+    private $request;
+    private $cookie;
+    private $jwt;
+    private $registration;
+    private $launch_id;
+
+    /**
+     * Constructor
+     *
+     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.
+     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
+     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.
+     */
+    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
+        $this->db = $database;
+
+        $this->launch_id = uniqid("lti1p3_launch_", true);
+
+        if ($cache === null) {
+            $cache = new Cache();
+        }
+        $this->cache = $cache;
+
+        if ($cookie === null) {
+            $cookie = new Cookie();
+        }
+        $this->cookie = $cookie;
+
+        JWT::$leeway = 5;
+    }
+
+    /**
+     * Static function to allow for method chaining without having to assign to a variable first.
+     */
+    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {
+        return new LTI_Message_Launch($database, $cache, $cookie);
+    }
+
+    /**
+     * Load an LTI_Message_Launch from a Cache using a launch id.
+     *
+     * @param string    $launch_id  The launch id of the LTI_Message_Launch object that is being pulled from the cache.
+     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.
+     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
+     *
+     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails or launch cannot be found.
+     * @return LTI_Message_Launch   A populated and validated LTI_Message_Launch.
+     */
+    public static function from_cache($launch_id, Database $database, Cache $cache = null) {
+        $new = new LTI_Message_Launch($database, $cache, null);
+        $new->launch_id = $launch_id;
+        $new->jwt = [ 'body' => $new->cache->get_launch_data($launch_id) ];
+        return $new->validate_registration();
+    }
+
+    /**
+     * Validates all aspects of an incoming LTI message launch and caches the launch if successful.
+     *
+     * @param array|string  $request    An array of post request parameters. If not set will default to $_POST.
+     *
+     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails.
+     * @return LTI_Message_Launch   Will return $this if validation is successful.
+     */
+    public function validate(array $request = null) {
+
+        if ($request === null) {
+            $request = $_POST;
+        }
+        $this->request = $request;
+
+        return $this->validate_state()
+            ->validate_jwt_format()
+            ->validate_nonce()
+            ->validate_registration()
+            ->validate_jwt_signature()
+            ->validate_deployment()
+            ->validate_message()
+            ->cache_launch_data();
+    }
+
+    /**
+     * Returns whether or not the current launch can use the names and roles service.
+     *
+     * @return boolean  Returns a boolean indicating the availability of names and roles.
+     */
+    public function has_nrps() {
+        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']['context_memberships_url']);
+    }
+
+    /**
+     * Fetches an instance of the names and roles service for the current launch.
+     *
+     * @return LTI_Names_Roles_Provisioning_Service An instance of the names and roles service that can be used to make calls within the scope of the current launch.
+     */
+    public function get_nrps() {
+        return new LTI_Names_Roles_Provisioning_Service(
+            new LTI_Service_Connector($this->registration),
+            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']);
+    }
+
+    /**
+     * Returns whether or not the current launch can use the groups service.
+     *
+     * @return boolean  Returns a boolean indicating the availability of groups.
+     */
+    public function has_gs() {
+        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']['context_groups_url']);
+    }
+
+    /**
+     * Fetches an instance of the groups service for the current launch.
+     *
+     * @return LTI_Course_Groups_Service An instance of the groups service that can be used to make calls within the scope of the current launch.
+     */
+    public function get_gs() {
+        return new LTI_Course_Groups_Service(
+            new LTI_Service_Connector($this->registration),
+            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']);
+    }
+
+    /**
+     * Returns whether or not the current launch can use the assignments and grades service.
+     *
+     * @return boolean  Returns a boolean indicating the availability of assignments and grades.
+     */
+    public function has_ags() {
+        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);
+    }
+
+    /**
+     * Fetches an instance of the assignments and grades service for the current launch.
+     *
+     * @return LTI_Assignments_Grades_Service An instance of the assignments an grades service that can be used to make calls within the scope of the current launch.
+     */
+    public function get_ags() {
+        return new LTI_Assignments_Grades_Service(
+            new LTI_Service_Connector($this->registration),
+            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);
+    }
+
+    /**
+     * Fetches a deep link that can be used to construct a deep linking response.
+     *
+     * @return LTI_Deep_Link An instance of a deep link to construct a deep linking response for the current launch.
+     */
+    public function get_deep_link() {
+        return new LTI_Deep_Link(
+            $this->registration,
+            $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],
+            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']);
+    }
+
+    /**
+     * Returns whether or not the current launch is a deep linking launch.
+     *
+     * @return boolean  Returns true if the current launch is a deep linking launch.
+     */
+    public function is_deep_link_launch() {
+        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiDeepLinkingRequest';
+    }
+
+    /**
+     * Returns whether or not the current launch is a submission review launch.
+     *
+     * @return boolean  Returns true if the current launch is a submission review launch.
+     */
+    public function is_submission_review_launch() {
+        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiSubmissionReviewRequest';
+    }
+
+    /**
+     * Returns whether or not the current launch is a resource launch.
+     *
+     * @return boolean  Returns true if the current launch is a resource launch.
+     */
+    public function is_resource_launch() {
+        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiResourceLinkRequest';
+    }
+
+    /**
+     * Fetches the decoded body of the JWT used in the current launch.
+     *
+     * @return array|object Returns the decoded json body of the launch as an array.
+     */
+    public function get_launch_data() {
+        return $this->jwt['body'];
+    }
+
+    /**
+     * Get the unique launch id for the current launch.
+     *
+     * @return string   A unique identifier used to re-reference the current launch in subsequent requests.
+     */
+    public function get_launch_id() {
+        return $this->launch_id;
+    }
+
+    /**
+     * Set Firebase\JWT leeway parameter to avoid synchronization issue between
+     * local server time and server which created the JWT
+     *
+     * @param int $leeway
+     *
+     * @return int
+     */
+    public function set_jwt_leeway( int $leeway ) {
+        JWT::$leeway = $leeway;
+        return JWT::$leeway;
+    }
+
+    private function get_public_key() {
+        $key_set_url = $this->registration->get_key_set_url();
+
+        // Download key set
+        $public_key_set = json_decode(file_get_contents($key_set_url), true);
+
+        if (empty($public_key_set)) {
+            // Failed to fetch public keyset from URL.
+            throw new LTI_Exception("Failed to fetch public key", 1);
+        }
+
+        // Find key used to sign the JWT (matches the KID in the header)
+        foreach ($public_key_set['keys'] as $key) {
+            if ($key['kid'] == $this->jwt['header']['kid']) {
+                try {
+                    return openssl_pkey_get_details(JWK::parseKey($key));
+                } catch(\Exception $e) {
+                    return false;
+                }
+            }
+        }
+
+        // Could not find public key with a matching kid and alg.
+        throw new LTI_Exception("Unable to find public key", 1);
+    }
+
+    private function cache_launch_data() {
+        $this->cache->cache_launch_data($this->launch_id, $this->jwt['body']);
+        return $this;
+    }
+
+    private function validate_state() {
+        // Check State for OIDC.
+        if ($this->cookie->get_cookie('lti1p3_' . $this->request['state']) !== $this->request['state']) {
+            // Error if state doesn't match
+            throw new LTI_Exception("State not found", 1);
+        }
+        return $this;
+    }
+
+    private function validate_jwt_format() {
+        $jwt = $this->request['id_token'];
+
+        if (empty($jwt)) {
+            throw new LTI_Exception("Missing id_token", 1);
+        }
+
+        // Get parts of JWT.
+        $jwt_parts = explode('.', $jwt);
+
+        if (count($jwt_parts) !== 3) {
+            // Invalid number of parts in JWT.
+            throw new LTI_Exception("Invalid id_token, JWT must contain 3 parts", 1);
+        }
+
+        // Decode JWT headers.
+        $this->jwt['header'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[0]), true);
+        // Decode JWT Body.
+        $this->jwt['body'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[1]), true);
+
+        return $this;
+    }
+
+    private function validate_nonce() {
+        if (!$this->cache->check_nonce($this->jwt['body']['nonce'])) {
+            //throw new LTI_Exception("Invalid Nonce");
+        }
+        return $this;
+    }
+
+    private function validate_registration() {
+        // Check client id.
+        $client_id = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];
+        // Find registration by iss and client_id.
+        $registrations = $this->db->filter_registrations([
+            'iss' => $this->jwt['body']['iss'],
+            'aud' => $client_id
+        ]);
+        if (!$registrations || count($registrations) === 0) {
+            throw new LTI_Exception("Registration not found.", 1);
+        }
+        $this->registration = $registrations[0];
+        return $this;
+    }
+
+    private function validate_jwt_signature() {
+        // Fetch public key.
+        $public_key = $this->get_public_key();
+
+        // Validate JWT signature
+        try {
+            JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));
+        } catch(\Exception $e) {
+            var_dump($e);
+            // Error validating signature.
+            throw new LTI_Exception("Invalid signature on id_token", 1);
+        }
+
+        return $this;
+    }
+
+    private function validate_deployment() {
+        // Find deployment.
+        $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id']);
+
+        if (empty($deployment)) {
+            // deployment not recognized.
+            throw new LTI_Exception("Unable to find deployment", 1);
+        }
+
+        return $this;
+    }
+
+    private function validate_message() {
+        if (empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'])) {
+            // Unable to identify message type.
+            throw new LTI_Exception("Invalid message type", 1);
+        }
+
+        // Do message type validation
+
+        // Import all validators
+        foreach (glob(__DIR__ . "/message_validators/*.php") as $filename) {
+            include_once $filename;
+        }
+
+        // Create instances of all validators
+        $classes = get_declared_classes();
+        $validators = array();
+        foreach ($classes as $class_name) {
+            // Check the class implements message validator
+            $reflect = new \ReflectionClass($class_name);
+            if ($reflect->implementsInterface('\IMSGlobal\LTI\Message_Validator')) {
+                // Create instance of class
+                $validators[] = new $class_name();
+            }
+        }
+
+        $message_validator = false;
+        foreach ($validators as $validator) {
+            if ($validator->can_validate($this->jwt['body'])) {
+                if ($message_validator !== false) {
+                    // Can't have more than one validator apply at a time.
+                    throw new LTI_Exception("Validator conflict", 1);
+                }
+                $message_validator = $validator;
+            }
+        }
+
+        if ($message_validator === false) {
+            throw new LTI_Exception("Unrecognized message type.", 1);
+        }
+
+        if (!$message_validator->validate($this->jwt['body'])) {
+            throw new LTI_Exception("Message validation failed.", 1);
+        }
+
+        return $this;
+
+    }
+}
+?>

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -1,382 +1,1 @@
-<?php
-namespace IMSGlobal\LTI;
-
-use Firebase\JWT\JWK;
-use Firebase\JWT\JWT;
-
-class LTI_Message_Launch {
-
-    private $db;
-    private $cache;
-    private $request;
-    private $cookie;
-    private $jwt;
-    private $registration;
-    private $launch_id;
-
-    /**
-     * Constructor
-     *
-     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.
-     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
-     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.
-     */
-    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
-        $this->db = $database;
-
-        $this->launch_id = uniqid("lti1p3_launch_", true);
-
-        if ($cache === null) {
-            $cache = new Cache();
-        }
-        $this->cache = $cache;
-
-        if ($cookie === null) {
-            $cookie = new Cookie();
-        }
-        $this->cookie = $cookie;
-
-        JWT::$leeway = 5;
-    }
-
-    /**
-     * Static function to allow for method chaining without having to assign to a variable first.
-     */
-    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {
-        return new LTI_Message_Launch($database, $cache, $cookie);
-    }
-
-    /**
-     * Load an LTI_Message_Launch from a Cache using a launch id.
-     *
-     * @param string    $launch_id  The launch id of the LTI_Message_Launch object that is being pulled from the cache.
-     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.
-     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
-     *
-     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails or launch cannot be found.
-     * @return LTI_Message_Launch   A populated and validated LTI_Message_Launch.
-     */
-    public static function from_cache($launch_id, Database $database, Cache $cache = null) {
-        $new = new LTI_Message_Launch($database, $cache, null);
-        $new->launch_id = $launch_id;
-        $new->jwt = [ 'body' => $new->cache->get_launch_data($launch_id) ];
-        return $new->validate_registration();
-    }
-
-    /**
-     * Validates all aspects of an incoming LTI message launch and caches the launch if successful.
-     *
-     * @param array|string  $request    An array of post request parameters. If not set will default to $_POST.
-     *
-     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails.
-     * @return LTI_Message_Launch   Will return $this if validation is successful.
-     */
-    public function validate(array $request = null) {
-
-        if ($request === null) {
-            $request = $_POST;
-        }
-        $this->request = $request;
-
-        return $this->validate_state()
-            ->validate_jwt_format()
-            ->validate_nonce()
-            ->validate_registration()
-            ->validate_jwt_signature()
-            ->validate_deployment()
-            ->validate_message()
-            ->cache_launch_data();
-    }
-
-    /**
-     * Returns whether or not the current launch can use the names and roles service.
-     *
-     * @return boolean  Returns a boolean indicating the availability of names and roles.
-     */
-    public function has_nrps() {
-        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']['context_memberships_url']);
-    }
-
-    /**
-     * Fetches an instance of the names and roles service for the current launch.
-     *
-     * @return LTI_Names_Roles_Provisioning_Service An instance of the names and roles service that can be used to make calls within the scope of the current launch.
-     */
-    public function get_nrps() {
-        return new LTI_Names_Roles_Provisioning_Service(
-            new LTI_Service_Connector($this->registration),
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']);
-    }
-
-    /**
-     * Returns whether or not the current launch can use the groups service.
-     *
-     * @return boolean  Returns a boolean indicating the availability of groups.
-     */
-    public function has_gs() {
-        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']['context_groups_url']);
-    }
-
-    /**
-     * Fetches an instance of the groups service for the current launch.
-     *
-     * @return LTI_Course_Groups_Service An instance of the groups service that can be used to make calls within the scope of the current launch.
-     */
-    public function get_gs() {
-        return new LTI_Course_Groups_Service(
-            new LTI_Service_Connector($this->registration),
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']);
-    }
-
-    /**
-     * Returns whether or not the current launch can use the assignments and grades service.
-     *
-     * @return boolean  Returns a boolean indicating the availability of assignments and grades.
-     */
-    public function has_ags() {
-        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);
-    }
-
-    /**
-     * Fetches an instance of the assignments and grades service for the current launch.
-     *
-     * @return LTI_Assignments_Grades_Service An instance of the assignments an grades service that can be used to make calls within the scope of the current launch.
-     */
-    public function get_ags() {
-        return new LTI_Assignments_Grades_Service(
-            new LTI_Service_Connector($this->registration),
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);
-    }
-
-    /**
-     * Fetches a deep link that can be used to construct a deep linking response.
-     *
-     * @return LTI_Deep_Link An instance of a deep link to construct a deep linking response for the current launch.
-     */
-    public function get_deep_link() {
-        return new LTI_Deep_Link(
-            $this->registration,
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']);
-    }
-
-    /**
-     * Returns whether or not the current launch is a deep linking launch.
-     *
-     * @return boolean  Returns true if the current launch is a deep linking launch.
-     */
-    public function is_deep_link_launch() {
-        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiDeepLinkingRequest';
-    }
-
-    /**
-     * Returns whether or not the current launch is a submission review launch.
-     *
-     * @return boolean  Returns true if the current launch is a submission review launch.
-     */
-    public function is_submission_review_launch() {
-        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiSubmissionReviewRequest';
-    }
-
-    /**
-     * Returns whether or not the current launch is a resource launch.
-     *
-     * @return boolean  Returns true if the current launch is a resource launch.
-     */
-    public function is_resource_launch() {
-        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiResourceLinkRequest';
-    }
-
-    /**
-     * Fetches the decoded body of the JWT used in the current launch.
-     *
-     * @return array|object Returns the decoded json body of the launch as an array.
-     */
-    public function get_launch_data() {
-        return $this->jwt['body'];
-    }
-
-    /**
-     * Get the unique launch id for the current launch.
-     *
-     * @return string   A unique identifier used to re-reference the current launch in subsequent requests.
-     */
-    public function get_launch_id() {
-        return $this->launch_id;
-    }
-
-    /**
-     * Set Firebase\JWT leeway parameter to avoid synchronization issue between
-     * local server time and server which created the JWT
-     *
-     * @param int $leeway
-     *
-     * @return int
-     */
-    public function set_jwt_leeway( int $leeway ) {
-        JWT::$leeway = $leeway;
-        return JWT::$leeway;
-    }
-
-    private function get_public_key() {
-        $key_set_url = $this->registration->get_key_set_url();
-
-        // Download key set
-        $public_key_set = json_decode(file_get_contents($key_set_url), true);
-
-        if (empty($public_key_set)) {
-            // Failed to fetch public keyset from URL.
-            throw new LTI_Exception("Failed to fetch public key", 1);
-        }
-
-        // Find key used to sign the JWT (matches the KID in the header)
-        foreach ($public_key_set['keys'] as $key) {
-            if ($key['kid'] == $this->jwt['header']['kid']) {
-                try {
-                    return openssl_pkey_get_details(JWK::parseKey($key));
-                } catch(\Exception $e) {
-                    return false;
-                }
-            }
-        }
-
-        // Could not find public key with a matching kid and alg.
-        throw new LTI_Exception("Unable to find public key", 1);
-    }
-
-    private function cache_launch_data() {
-        $this->cache->cache_launch_data($this->launch_id, $this->jwt['body']);
-        return $this;
-    }
-
-    private function validate_state() {
-        // Check State for OIDC.
-        if ($this->cookie->get_cookie('lti1p3_' . $this->request['state']) !== $this->request['state']) {
-            // Error if state doesn't match
-            throw new LTI_Exception("State not found", 1);
-        }
-        return $this;
-    }
-
-    private function validate_jwt_format() {
-        $jwt = $this->request['id_token'];
-
-        if (empty($jwt)) {
-            throw new LTI_Exception("Missing id_token", 1);
-        }
-
-        // Get parts of JWT.
-        $jwt_parts = explode('.', $jwt);
-
-        if (count($jwt_parts) !== 3) {
-            // Invalid number of parts in JWT.
-            throw new LTI_Exception("Invalid id_token, JWT must contain 3 parts", 1);
-        }
-
-        // Decode JWT headers.
-        $this->jwt['header'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[0]), true);
-        // Decode JWT Body.
-        $this->jwt['body'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[1]), true);
-
-        return $this;
-    }
-
-    private function validate_nonce() {
-        if (!$this->cache->check_nonce($this->jwt['body']['nonce'])) {
-            //throw new LTI_Exception("Invalid Nonce");
-        }
-        return $this;
-    }
-
-    private function validate_registration() {
-        // Check client id.
-        $client_id = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];
-        // Find registration by iss and client_id.
-        $registrations = $this->db->filter_registrations([
-            'iss' => $this->jwt['body']['iss'],
-            'aud' => $client_id
-        ]);
-        if (!$registrations || count($registrations) === 0) {
-            throw new LTI_Exception("Registration not found.", 1);
-        }
-        $this->registration = $registrations[0];
-        return $this;
-    }
-
-    private function validate_jwt_signature() {
-        // Fetch public key.
-        $public_key = $this->get_public_key();
-
-        // Validate JWT signature
-        try {
-            JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));
-        } catch(\Exception $e) {
-            var_dump($e);
-            // Error validating signature.
-            throw new LTI_Exception("Invalid signature on id_token", 1);
-        }
-
-        return $this;
-    }
-
-    private function validate_deployment() {
-        // Find deployment.
-        $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id']);
-
-        if (empty($deployment)) {
-            // deployment not recognized.
-            throw new LTI_Exception("Unable to find deployment", 1);
-        }
-
-        return $this;
-    }
-
-    private function validate_message() {
-        if (empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'])) {
-            // Unable to identify message type.
-            throw new LTI_Exception("Invalid message type", 1);
-        }
-
-        // Do message type validation
-
-        // Import all validators
-        foreach (glob(__DIR__ . "/message_validators/*.php") as $filename) {
-            include_once $filename;
-        }
-
-        // Create instances of all validators
-        $classes = get_declared_classes();
-        $validators = array();
-        foreach ($classes as $class_name) {
-            // Check the class implements message validator
-            $reflect = new \ReflectionClass($class_name);
-            if ($reflect->implementsInterface('\IMSGlobal\LTI\Message_Validator')) {
-                // Create instance of class
-                $validators[] = new $class_name();
-            }
-        }
-
-        $message_validator = false;
-        foreach ($validators as $validator) {
-            if ($validator->can_validate($this->jwt['body'])) {
-                if ($message_validator !== false) {
-                    // Can't have more than one validator apply at a time.
-                    throw new LTI_Exception("Validator conflict", 1);
-                }
-                $message_validator = $validator;
-            }
-        }
-
-        if ($message_validator === false) {
-            throw new LTI_Exception("Unrecognized message type.", 1);
-        }
-
-        if (!$message_validator->validate($this->jwt['body'])) {
-            throw new LTI_Exception("Message validation failed.", 1);
-        }
-
-        return $this;
-
-    }
-}
-?>
+<?phpnamespace IMSGlobal\LTI;use Firebase\JWT\JWK;use Firebase\JWT\JWT;class LTI_Message_Launch {    private $db;    private $cache;    private $request;    private $cookie;    private $jwt;    private $registration;    private $launch_id;    /**     * Constructor     *     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.     */    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {        $this->db = $database;        $this->launch_id = uniqid("lti1p3_launch_", true);        if ($cache === null) {            $cache = new Cache();        }        $this->cache = $cache;        if ($cookie === null) {            $cookie = new Cookie();        }        $this->cookie = $cookie;        JWT::$leeway = 5;    }    /**     * Static function to allow for method chaining without having to assign to a variable first.     */    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {        return new LTI_Message_Launch($database, $cache, $cookie);    }    /**     * Load an LTI_Message_Launch from a Cache using a launch id.     *     * @param string    $launch_id  The launch id of the LTI_Message_Launch object that is being pulled from the cache.     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.     *     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails or launch cannot be found.     * @return LTI_Message_Launch   A populated and validated LTI_Message_Launch.     */    public static function from_cache($launch_id, Database $database, Cache $cache = null) {        $new = new LTI_Message_Launch($database, $cache, null);        $new->launch_id = $launch_id;        $new->jwt = [ 'body' => $new->cache->get_launch_data($launch_id) ];        return $new->validate_registration();    }    /**     * Validates all aspects of an incoming LTI message launch and caches the launch if successful.     *     * @param array|string  $request    An array of post request parameters. If not set will default to $_POST.     *     * @throws LTI_Exception        Will throw an LTI_Exception if validation fails.     * @return LTI_Message_Launch   Will return $this if validation is successful.     */    public function validate(array $request = null) {        if ($request === null) {            $request = $_POST;        }        $this->request = $request;        return $this->validate_state()            ->validate_jwt_format()            ->validate_nonce()            ->validate_registration()            ->validate_jwt_signature()            ->validate_deployment()            ->validate_message()            ->cache_launch_data();    }    /**     * Returns whether or not the current launch can use the names and roles service.     *     * @return boolean  Returns a boolean indicating the availability of names and roles.     */    public function has_nrps() {        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']['context_memberships_url']);    }    /**     * Fetches an instance of the names and roles service for the current launch.     *     * @return LTI_Names_Roles_Provisioning_Service An instance of the names and roles service that can be used to make calls within the scope of the current launch.     */    public function get_nrps() {        return new LTI_Names_Roles_Provisioning_Service(            new LTI_Service_Connector($this->registration),            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']);    }    /**     * Returns whether or not the current launch can use the groups service.     *     * @return boolean  Returns a boolean indicating the availability of groups.     */    public function has_gs() {        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']['context_groups_url']);    }    /**     * Fetches an instance of the groups service for the current launch.     *     * @return LTI_Course_Groups_Service An instance of the groups service that can be used to make calls within the scope of the current launch.     */    public function get_gs() {        return new LTI_Course_Groups_Service(            new LTI_Service_Connector($this->registration),            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-gs/claim/groupsservice']);    }    /**     * Returns whether or not the current launch can use the assignments and grades service.     *     * @return boolean  Returns a boolean indicating the availability of assignments and grades.     */    public function has_ags() {        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);    }    /**     * Fetches an instance of the assignments and grades service for the current launch.     *     * @return LTI_Assignments_Grades_Service An instance of the assignments an grades service that can be used to make calls within the scope of the current launch.     */    public function get_ags() {        return new LTI_Assignments_Grades_Service(            new LTI_Service_Connector($this->registration),            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);    }    /**     * Fetches a deep link that can be used to construct a deep linking response.     *     * @return LTI_Deep_Link An instance of a deep link to construct a deep linking response for the current launch.     */    public function get_deep_link() {        return new LTI_Deep_Link(            $this->registration,            $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']);    }    /**     * Returns whether or not the current launch is a deep linking launch.     *     * @return boolean  Returns true if the current launch is a deep linking launch.     */    public function is_deep_link_launch() {        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiDeepLinkingRequest';    }    /**     * Returns whether or not the current launch is a submission review launch.     *     * @return boolean  Returns true if the current launch is a submission review launch.     */    public function is_submission_review_launch() {        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiSubmissionReviewRequest';    }    /**     * Returns whether or not the current launch is a resource launch.     *     * @return boolean  Returns true if the current launch is a resource launch.     */    public function is_resource_launch() {        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiResourceLinkRequest';    }    /**     * Fetches the decoded body of the JWT used in the current launch.     *     * @return array|object Returns the decoded json body of the launch as an array.     */    public function get_launch_data() {        return $this->jwt['body'];    }    /**     * Get the unique launch id for the current launch.     *     * @return string   A unique identifier used to re-reference the current launch in subsequent requests.     */    public function get_launch_id() {        return $this->launch_id;    }    /**     * Set Firebase\JWT leeway parameter to avoid synchronization issue between     * local server time and server which created the JWT     *     * @param int $leeway     *     * @return int     */    public function set_jwt_leeway( int $leeway ) {        JWT::$leeway = $leeway;        return JWT::$leeway;    }    private function get_public_key() {        $key_set_url = $this->registration->get_key_set_url();        // Download key set        $public_key_set = json_decode(file_get_contents($key_set_url), true);        if (empty($public_key_set)) {            // Failed to fetch public keyset from URL.            throw new LTI_Exception("Failed to fetch public key", 1);        }        // Find key used to sign the JWT (matches the KID in the header)        foreach ($public_key_set['keys'] as $key) {            if ($key['kid'] == $this->jwt['header']['kid']) {                try {                    return openssl_pkey_get_details(JWK::parseKey($key));                } catch(\Exception $e) {                    return false;                }            }        }        // Could not find public key with a matching kid and alg.        throw new LTI_Exception("Unable to find public key", 1);    }    private function cache_launch_data() {        $this->cache->cache_launch_data($this->launch_id, $this->jwt['body']);        return $this;    }    private function validate_state() {        // Check State for OIDC.        if ($this->cookie->get_cookie('lti1p3_' . $this->request['state']) !== $this->request['state']) {            // Error if state doesn't match            throw new LTI_Exception("State not found", 1);        }        return $this;    }    private function validate_jwt_format() {        $jwt = $this->request['id_token'];        if (empty($jwt)) {            throw new LTI_Exception("Missing id_token", 1);        }        // Get parts of JWT.        $jwt_parts = explode('.', $jwt);        if (count($jwt_parts) !== 3) {            // Invalid number of parts in JWT.            throw new LTI_Exception("Invalid id_token, JWT must contain 3 parts", 1);        }        // Decode JWT headers.        $this->jwt['header'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[0]), true);        // Decode JWT Body.        $this->jwt['body'] = json_decode(JWT::urlsafeB64Decode($jwt_parts[1]), true);        return $this;    }    private function validate_nonce() {        if (!$this->cache->check_nonce($this->jwt['body']['nonce'])) {            //throw new LTI_Exception("Invalid Nonce");        }        return $this;    }    private function validate_registration() {        // Check client id.        $client_id = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];        // Find registration by iss and client_id.        $registrations = $this->db->filter_registrations([            'iss' => $this->jwt['body']['iss'],            'aud' => $client_id        ]);        if (!$registrations || count($registrations) === 0) {            throw new LTI_Exception("Registration not found.", 1);        }        $this->registration = $registrations[0];        return $this;    }    private function validate_jwt_signature() {        // Fetch public key.        $public_key = $this->get_public_key();        // Validate JWT signature        try {            JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));        } catch(\Exception $e) {            var_dump($e);            // Error validating signature.            throw new LTI_Exception("Invalid signature on id_token", 1);        }        return $this;    }    private function validate_deployment() {        // Find deployment.        $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id']);        if (empty($deployment)) {            // deployment not recognized.            throw new LTI_Exception("Unable to find deployment", 1);        }        return $this;    }    private function validate_message() {        if (empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'])) {            // Unable to identify message type.            throw new LTI_Exception("Invalid message type", 1);        }        // Do message type validation        // Import all validators        foreach (glob(__DIR__ . "/message_validators/*.php") as $filename) {            include_once $filename;        }        // Create instances of all validators        $classes = get_declared_classes();        $validators = array();        foreach ($classes as $class_name) {            // Check the class implements message validator            $reflect = new \ReflectionClass($class_name);            if ($reflect->implementsInterface('\IMSGlobal\LTI\Message_Validator')) {                // Create instance of class                $validators[] = new $class_name();            }        }        $message_validator = false;        foreach ($validators as $validator) {            if ($validator->can_validate($this->jwt['body'])) {                if ($message_validator !== false) {                    // Can't have more than one validator apply at a time.                    throw new LTI_Exception("Validator conflict", 1);                }                $message_validator = $validator;            }        }        if ($message_validator === false) {            throw new LTI_Exception("Unrecognized message type.", 1);        }        if (!$message_validator->validate($this->jwt['body'])) {            throw new LTI_Exception("Message validation failed.", 1);        }        return $this;    }}?>

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -289,20 +289,17 @@ class LTI_Message_Launch {
     }
 
     private function validate_registration() {
-        // Find registration.
-        $this->registration = $this->db->find_registration_by_issuer($this->jwt['body']['iss']);
-
-        if (empty($this->registration)) {
-            throw new LTI_Exception("Registration not found.", 1);
-        }
-
         // Check client id.
         $client_id = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];
-        if ( $client_id !== $this->registration->get_client_id()) {
-            // Client not registered.
-            throw new LTI_Exception("Client id not registered for this issuer", 1);
+        // Find registration by iss and client_id.
+        $registrations = $this->db->filter_registrations([
+            'iss' => $this->jwt['body']['iss'],
+            'aud' => $client_id
+        ]);
+        if (!$registrations || count($registrations) === 0) {
+            throw new LTI_Exception("Registration not found.", 1);
         }
-
+        $this->registration = $registrations[0];
         return $this;
     }
 

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -106,15 +106,23 @@ class LTI_OIDC_Login {
             throw new OIDC_Exception("Could not find login hint", 1);
         }
 
+        // Validate Client ID.
+        if (empty($request['aud'])) {
+            throw new OIDC_Exception("Could not find aud", 1);
+        }
+
         // Fetch Registration Details.
-        $registration = $this->db->find_registration_by_issuer($request['iss']);
+        $registrations = $this->db->filter_registrations([
+            'iss' => $request['iss'],
+            'aud' => $request['aud']
+        ]);
 
         // Check we got something.
-        if (empty($registration)) {
+        if (!$registrations || count($registrations) === 0) {
             throw new OIDC_Exception("Could not find registration details", 1);
         }
 
         // Return Registration.
-        return $registration;
+        return $registrations[0];
     }
 }

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -1,128 +1,1 @@
-<?php
-namespace IMSGlobal\LTI;
-
-class LTI_OIDC_Login {
-
-    private $db;
-    private $cache;
-    private $cookie;
-
-    /**
-     * Constructor
-     *
-     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.
-     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
-     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.
-     */
-    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
-        $this->db = $database;
-        if ($cache === null) {
-            $cache = new Cache();
-        }
-        $this->cache = $cache;
-
-        if ($cookie === null) {
-            $cookie = new Cookie();
-        }
-        $this->cookie = $cookie;
-    }
-
-    /**
-     * Static function to allow for method chaining without having to assign to a variable first.
-     */
-    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {
-        return new LTI_OIDC_Login($database, $cache, $cookie);
-    }
-
-    /**
-     * Calculate the redirect location to return to based on an OIDC third party initiated login request.
-     *
-     * @param string        $launch_url URL to redirect back to after the OIDC login. This URL must match exactly a URL white listed in the platform.
-     * @param array|string  $request    An array of request parameters. If not set will default to $_REQUEST.
-     *
-     * @return Redirect Returns a redirect object containing the fully formed OIDC login URL.
-     */
-    public function do_oidc_login_redirect($launch_url, array $request = null) {
-
-        if ($request === null) {
-            $request = $_REQUEST;
-        }
-
-        if (empty($launch_url)) {
-            throw new OIDC_Exception("No launch URL configured", 1);
-        }
-
-        // Validate Request Data.
-        $registration = $this->validate_oidc_login($request);
-
-        /*
-         * Build OIDC Auth Response.
-         */
-
-        // Generate State.
-        // Set cookie (short lived)
-        $state = str_replace('.', '_', uniqid('state-', true));
-        $this->cookie->set_cookie("lti1p3_$state", $state, 60);
-
-        // Generate Nonce.
-        $nonce = uniqid('nonce-', true);
-        $this->cache->cache_nonce($nonce);
-
-        // Build Response.
-        $auth_params = [
-            'scope'         => 'openid', // OIDC Scope.
-            'response_type' => 'id_token', // OIDC response is always an id token.
-            'response_mode' => 'form_post', // OIDC response is always a form post.
-            'prompt'        => 'none', // Don't prompt user on redirect.
-            'client_id'     => $registration->get_client_id(), // Registered client id.
-            'redirect_uri'  => $launch_url, // URL to return to after login.
-            'state'         => $state, // State to identify browser session.
-            'nonce'         => $nonce, // Prevent replay attacks.
-            'login_hint'    => $request['login_hint'] // Login hint to identify platform session.
-        ];
-
-        // Pass back LTI message hint if we have it.
-        if (isset($request['lti_message_hint'])) {
-            // LTI message hint to identify LTI context within the platform.
-            $auth_params['lti_message_hint'] = $request['lti_message_hint'];
-        }
-
-        $auth_login_return_url = $registration->get_auth_login_url() . "?" . http_build_query($auth_params);
-
-        // Return auth redirect.
-        return new Redirect($auth_login_return_url, http_build_query($request));
-
-    }
-
-    protected function validate_oidc_login($request) {
-
-        // Validate Issuer.
-        if (empty($request['iss'])) {
-            throw new OIDC_Exception("Could not find issuer", 1);
-        }
-
-        // Validate Login Hint.
-        if (empty($request['login_hint'])) {
-            throw new OIDC_Exception("Could not find login hint", 1);
-        }
-
-        // Validate Client ID.
-        if (empty($request['aud'])) {
-            throw new OIDC_Exception("Could not find aud", 1);
-        }
-
-        // Fetch Registration Details.
-        $registrations = $this->db->filter_registrations([
-            'iss' => $request['iss'],
-            'aud' => $request['aud']
-        ]);
-
-        // Check we got something.
-        if (!$registrations || count($registrations) === 0) {
-            throw new OIDC_Exception("Could not find registration details", 1);
-        }
-
-        // Return Registration.
-        return $registrations[0];
-    }
-}
+<?phpnamespace IMSGlobal\LTI;class LTI_OIDC_Login {    private $db;    private $cache;    private $cookie;    /**     * Constructor     *     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.     */    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {        $this->db = $database;        if ($cache === null) {            $cache = new Cache();        }        $this->cache = $cache;        if ($cookie === null) {            $cookie = new Cookie();        }        $this->cookie = $cookie;    }    /**     * Static function to allow for method chaining without having to assign to a variable first.     */    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {        return new LTI_OIDC_Login($database, $cache, $cookie);    }    /**     * Calculate the redirect location to return to based on an OIDC third party initiated login request.     *     * @param string        $launch_url URL to redirect back to after the OIDC login. This URL must match exactly a URL white listed in the platform.     * @param array|string  $request    An array of request parameters. If not set will default to $_REQUEST.     *     * @return Redirect Returns a redirect object containing the fully formed OIDC login URL.     */    public function do_oidc_login_redirect($launch_url, array $request = null) {        if ($request === null) {            $request = $_REQUEST;        }        if (empty($launch_url)) {            throw new OIDC_Exception("No launch URL configured", 1);        }        // Validate Request Data.        $registration = $this->validate_oidc_login($request);        /*         * Build OIDC Auth Response.         */        // Generate State.        // Set cookie (short lived)        $state = str_replace('.', '_', uniqid('state-', true));        $this->cookie->set_cookie("lti1p3_$state", $state, 60);        // Generate Nonce.        $nonce = uniqid('nonce-', true);        $this->cache->cache_nonce($nonce);        // Build Response.        $auth_params = [            'scope'         => 'openid', // OIDC Scope.            'response_type' => 'id_token', // OIDC response is always an id token.            'response_mode' => 'form_post', // OIDC response is always a form post.            'prompt'        => 'none', // Don't prompt user on redirect.            'client_id'     => $registration->get_client_id(), // Registered client id.            'redirect_uri'  => $launch_url, // URL to return to after login.            'state'         => $state, // State to identify browser session.            'nonce'         => $nonce, // Prevent replay attacks.            'login_hint'    => $request['login_hint'] // Login hint to identify platform session.        ];        // Pass back LTI message hint if we have it.        if (isset($request['lti_message_hint'])) {            // LTI message hint to identify LTI context within the platform.            $auth_params['lti_message_hint'] = $request['lti_message_hint'];        }        $auth_login_return_url = $registration->get_auth_login_url() . "?" . http_build_query($auth_params);        // Return auth redirect.        return new Redirect($auth_login_return_url, http_build_query($request));    }    protected function validate_oidc_login($request) {        // Validate Issuer.        if (empty($request['iss'])) {            throw new OIDC_Exception("Could not find issuer", 1);        }        // Validate Login Hint.        if (empty($request['login_hint'])) {            throw new OIDC_Exception("Could not find login hint", 1);        }        // Validate Client ID.        if (empty($request['aud'])) {            throw new OIDC_Exception("Could not find aud", 1);        }        // Fetch Registration Details.        $registrations = $this->db->filter_registrations([            'iss' => $request['iss'],            'aud' => $request['aud']        ]);        // Check we got something.        if (!$registrations || count($registrations) === 0) {            throw new OIDC_Exception("Could not find registration details", 1);        }        // Return Registration.        return $registrations[0];    }}

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -1,1 +1,128 @@
-<?phpnamespace IMSGlobal\LTI;class LTI_OIDC_Login {    private $db;    private $cache;    private $cookie;    /**     * Constructor     *     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.     */    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {        $this->db = $database;        if ($cache === null) {            $cache = new Cache();        }        $this->cache = $cache;        if ($cookie === null) {            $cookie = new Cookie();        }        $this->cookie = $cookie;    }    /**     * Static function to allow for method chaining without having to assign to a variable first.     */    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {        return new LTI_OIDC_Login($database, $cache, $cookie);    }    /**     * Calculate the redirect location to return to based on an OIDC third party initiated login request.     *     * @param string        $launch_url URL to redirect back to after the OIDC login. This URL must match exactly a URL white listed in the platform.     * @param array|string  $request    An array of request parameters. If not set will default to $_REQUEST.     *     * @return Redirect Returns a redirect object containing the fully formed OIDC login URL.     */    public function do_oidc_login_redirect($launch_url, array $request = null) {        if ($request === null) {            $request = $_REQUEST;        }        if (empty($launch_url)) {            throw new OIDC_Exception("No launch URL configured", 1);        }        // Validate Request Data.        $registration = $this->validate_oidc_login($request);        /*         * Build OIDC Auth Response.         */        // Generate State.        // Set cookie (short lived)        $state = str_replace('.', '_', uniqid('state-', true));        $this->cookie->set_cookie("lti1p3_$state", $state, 60);        // Generate Nonce.        $nonce = uniqid('nonce-', true);        $this->cache->cache_nonce($nonce);        // Build Response.        $auth_params = [            'scope'         => 'openid', // OIDC Scope.            'response_type' => 'id_token', // OIDC response is always an id token.            'response_mode' => 'form_post', // OIDC response is always a form post.            'prompt'        => 'none', // Don't prompt user on redirect.            'client_id'     => $registration->get_client_id(), // Registered client id.            'redirect_uri'  => $launch_url, // URL to return to after login.            'state'         => $state, // State to identify browser session.            'nonce'         => $nonce, // Prevent replay attacks.            'login_hint'    => $request['login_hint'] // Login hint to identify platform session.        ];        // Pass back LTI message hint if we have it.        if (isset($request['lti_message_hint'])) {            // LTI message hint to identify LTI context within the platform.            $auth_params['lti_message_hint'] = $request['lti_message_hint'];        }        $auth_login_return_url = $registration->get_auth_login_url() . "?" . http_build_query($auth_params);        // Return auth redirect.        return new Redirect($auth_login_return_url, http_build_query($request));    }    protected function validate_oidc_login($request) {        // Validate Issuer.        if (empty($request['iss'])) {            throw new OIDC_Exception("Could not find issuer", 1);        }        // Validate Login Hint.        if (empty($request['login_hint'])) {            throw new OIDC_Exception("Could not find login hint", 1);        }        // Validate Client ID.        if (empty($request['aud'])) {            throw new OIDC_Exception("Could not find aud", 1);        }        // Fetch Registration Details.        $registrations = $this->db->filter_registrations([            'iss' => $request['iss'],            'aud' => $request['aud']        ]);        // Check we got something.        if (!$registrations || count($registrations) === 0) {            throw new OIDC_Exception("Could not find registration details", 1);        }        // Return Registration.        return $registrations[0];    }}
+<?php
+namespace IMSGlobal\LTI;
+
+class LTI_OIDC_Login {
+
+    private $db;
+    private $cache;
+    private $cookie;
+
+    /**
+     * Constructor
+     *
+     * @param Database  $database   Instance of the database interface used for looking up registrations and deployments.
+     * @param Cache     $cache      Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
+     * @param Cookie    $cookie     Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.
+     */
+    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
+        $this->db = $database;
+        if ($cache === null) {
+            $cache = new Cache();
+        }
+        $this->cache = $cache;
+
+        if ($cookie === null) {
+            $cookie = new Cookie();
+        }
+        $this->cookie = $cookie;
+    }
+
+    /**
+     * Static function to allow for method chaining without having to assign to a variable first.
+     */
+    public static function new(Database $database, Cache $cache = null, Cookie $cookie = null) {
+        return new LTI_OIDC_Login($database, $cache, $cookie);
+    }
+
+    /**
+     * Calculate the redirect location to return to based on an OIDC third party initiated login request.
+     *
+     * @param string        $launch_url URL to redirect back to after the OIDC login. This URL must match exactly a URL white listed in the platform.
+     * @param array|string  $request    An array of request parameters. If not set will default to $_REQUEST.
+     *
+     * @return Redirect Returns a redirect object containing the fully formed OIDC login URL.
+     */
+    public function do_oidc_login_redirect($launch_url, array $request = null) {
+
+        if ($request === null) {
+            $request = $_REQUEST;
+        }
+
+        if (empty($launch_url)) {
+            throw new OIDC_Exception("No launch URL configured", 1);
+        }
+
+        // Validate Request Data.
+        $registration = $this->validate_oidc_login($request);
+
+        /*
+         * Build OIDC Auth Response.
+         */
+
+        // Generate State.
+        // Set cookie (short lived)
+        $state = str_replace('.', '_', uniqid('state-', true));
+        $this->cookie->set_cookie("lti1p3_$state", $state, 60);
+
+        // Generate Nonce.
+        $nonce = uniqid('nonce-', true);
+        $this->cache->cache_nonce($nonce);
+
+        // Build Response.
+        $auth_params = [
+            'scope'         => 'openid', // OIDC Scope.
+            'response_type' => 'id_token', // OIDC response is always an id token.
+            'response_mode' => 'form_post', // OIDC response is always a form post.
+            'prompt'        => 'none', // Don't prompt user on redirect.
+            'client_id'     => $registration->get_client_id(), // Registered client id.
+            'redirect_uri'  => $launch_url, // URL to return to after login.
+            'state'         => $state, // State to identify browser session.
+            'nonce'         => $nonce, // Prevent replay attacks.
+            'login_hint'    => $request['login_hint'] // Login hint to identify platform session.
+        ];
+
+        // Pass back LTI message hint if we have it.
+        if (isset($request['lti_message_hint'])) {
+            // LTI message hint to identify LTI context within the platform.
+            $auth_params['lti_message_hint'] = $request['lti_message_hint'];
+        }
+
+        $auth_login_return_url = $registration->get_auth_login_url() . "?" . http_build_query($auth_params);
+
+        // Return auth redirect.
+        return new Redirect($auth_login_return_url, http_build_query($request));
+
+    }
+
+    protected function validate_oidc_login($request) {
+
+        // Validate Issuer.
+        if (empty($request['iss'])) {
+            throw new OIDC_Exception("Could not find issuer", 1);
+        }
+
+        // Validate Login Hint.
+        if (empty($request['login_hint'])) {
+            throw new OIDC_Exception("Could not find login hint", 1);
+        }
+
+        // Validate Client ID.
+        if (empty($request['aud'])) {
+            throw new OIDC_Exception("Could not find aud", 1);
+        }
+
+        // Fetch Registration Details.
+        $registrations = $this->db->filter_registrations([
+            'iss' => $request['iss'],
+            'aud' => $request['aud']
+        ]);
+
+        // Check we got something.
+        if (!$registrations || count($registrations) === 0) {
+            throw new OIDC_Exception("Could not find registration details", 1);
+        }
+
+        // Return Registration.
+        return $registrations[0];
+    }
+}


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-lti-provider-1p3/issues/95

Consumers are filtered and identified by `iss` parameter, which means if two consumers contains the same `iss` only the first occurrence will be returned.
Database class interface was changed in order to implement a new method: `filter_registrations`, it will allow to filter consumers using any combination of available properties.

Also, `find_registration_by_issuer` function is avoided in order to identify consumers by `iss`.